### PR TITLE
Add script in dockerfile to get latest release of proxysql

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:stretch
+MAINTAINER Ashraf Sharif <ashraf@severalnines.com>
+
+RUN apt-get update && \
+    apt-get install -y curl wget mysql-client inotify-tools procps && \
+    curl -s https://api.github.com/repos/sysown/proxysql/releases/latest \
+    | grep browser_download_url \
+    | grep debian9 \
+    | cut -d '"' -f 4 \
+    | grep -Ev "clickhouse|dbg" \
+    | wget -O /opt/proxysql_latest-debian9_amd64.deb -i - && \
+    dpkg -i /opt/proxysql_latest-debian9_amd64.deb && \
+    rm -f /opt/proxysql_latest-debian9_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+VOLUME /var/lib/proxysql
+EXPOSE 6032 6033
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/lib/proxysql
-EXPOSE 6032 6033
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/latest/entrypoint.sh
+++ b/latest/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+## ProxySQL entrypoint
+## ===================
+##
+## Supported environment variable:
+##
+## MONITOR_CONFIG_CHANGE={true|false}
+## - Monitor /etc/proxysql.cnf for any changes and reload ProxySQL automatically
+
+# If command has arguments, prepend proxysql
+if [ "${1:0:1}" = '-' ]; then
+	CMDARG="$@"
+fi
+
+if [ $MONITOR_CONFIG_CHANGE ]; then
+
+	echo 'Env MONITOR_CONFIG_CHANGE=true'
+	CONFIG=/etc/proxysql.cnf
+	oldcksum=$(cksum ${CONFIG})
+
+	# Start ProxySQL in the background
+	proxysql --reload -f $CMDARG &
+
+	echo "Monitoring $CONFIG for changes.."
+	inotifywait -e modify,move,create,delete -m --timefmt '%d/%m/%y %H:%M' --format '%T' ${CONFIG} | \
+	while read date time; do
+		newcksum=$(cksum ${CONFIG})
+		if [ "$newcksum" != "$oldcksum" ]; then
+			echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+			echo "At ${time} on ${date}, ${CONFIG} update detected."
+			echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+			oldcksum=$newcksum
+			echo "Reloading ProxySQL.."
+		        killall -15 proxysql
+			proxysql --initial --reload -f $CMDARG
+		fi
+	done
+fi
+
+# Start ProxySQL with PID 1
+exec proxysql -f $CMDARG


### PR DESCRIPTION
Remove `ENV VERSION` in dockerfile. Get latest release from proxysql official repo. `entrypoint.sh` is not touched.