### PR TITLE
add mysql-client to 2.0 Dockerfile

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ashraf Sharif <ashraf@severalnines.com>
 ENV VERSION 2.0.3
 
 RUN apt-get update && \
-    apt-get install -y wget inotify-tools procps && \
+    apt-get install -y wget mysql-client inotify-tools procps && \
     wget https://github.com/sysown/proxysql/releases/download/v${VERSION}/proxysql_${VERSION}-debian9_amd64.deb -O /opt/proxysql_${VERSION}-debian9_amd64.deb && \
     dpkg -i /opt/proxysql_${VERSION}-debian9_amd64.deb && \
     rm -f /opt/proxysql_${VERSION}-debian9_amd64.deb && \


### PR DESCRIPTION
mysql-client is missing from the ProxySQL 2.0 Dockerfile. This is needed in order to access ProxySQL as "admin".